### PR TITLE
Add MinLevel in the config file

### DIFF
--- a/conf/BuffCommand.conf.dist
+++ b/conf/BuffCommand.conf.dist
@@ -11,7 +11,6 @@
 
 BuffCommand.Cooldown = 120
 
-# 
 #
 #    BuffCommand.MinLevel
 #        Description: Minimum level to use .buff command, use 0 to disable minimum level requirement

--- a/conf/BuffCommand.conf.dist
+++ b/conf/BuffCommand.conf.dist
@@ -11,7 +11,7 @@
 
 BuffCommand.Cooldown = 120
 
-# Settings to control the minimum level of .buff command
+# 
 #
 #    BuffCommand.MinLevel
 #        Description: Minimum level to use .buff command, use 0 to disable minimum level requirement

--- a/conf/BuffCommand.conf.dist
+++ b/conf/BuffCommand.conf.dist
@@ -11,5 +11,14 @@
 
 BuffCommand.Cooldown = 120
 
+# Settings to control the minimum level of .buff command
+#
+#    BuffCommand.MinLevel
+#        Description: Minimum level to use .buff command, use 0 to disable minimum level requirement
+#        Default:     80 - (Enabled)
+#                     0 - (Disabled)
+
+BuffCommand.MinLevel = 80
+
 #
 ###################################################################################################

--- a/src/BuffCommand.cpp
+++ b/src/BuffCommand.cpp
@@ -51,7 +51,7 @@ public:
 		std::string ArgStr = (char*)args;
 
 		if (sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80) > 0) {
-			int MinLevel  = sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80);
+			uint8 MinLevel  = sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80);
 			if (player->getLevel() < sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80))
 			{
 				std::string MinLevelError = "You must be ";

--- a/src/BuffCommand.cpp
+++ b/src/BuffCommand.cpp
@@ -50,6 +50,20 @@ public:
 		Player* player = handler->GetSession()->GetPlayer();
 		std::string ArgStr = (char*)args;
 
+		if (sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80) > 0) {
+			int MinLevel  = sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80);
+			if (player->getLevel() < sConfigMgr->GetIntDefault("BuffCommand.MinLevel", 80))
+			{
+				std::string MinLevelError = "You must be ";
+				if (MinLevel != 80)
+					MinLevelError += "atleast ";
+				MinLevelError += "level " + std::to_string(MinLevel) + " to use this command.";
+				handler->SendSysMessage((MinLevelError).c_str());
+	            handler->SetSentErrorMessage(true);
+				return false;
+			}
+		}
+
 		if (ArgStr == "reload" && AccountMgr::IsAdminAccount(player->GetSession()->GetSecurity()))
 		{
 			sLog->outString("Re-Loading Player Buff data...");


### PR DESCRIPTION
Having MinLevel in the config file you can disable the opportunity for low level characters to use the buffs in their advantages if the owner of the server wants to.

This will give the module more customization ( so it can be used on fun servers by using "0" and having no MinLevel required, or having more fun at level 80 using MinLevel = 80, who knows, the fact is that you can now )